### PR TITLE
INFRA-4134 Add GCC-6.4.0.eb

### DIFF
--- a/easybuild/easyconfigs/g/GCC/GCC-6.4.0.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-6.4.0.eb
@@ -1,0 +1,31 @@
+easyblock = 'Bundle'
+
+name = 'GCC'
+version = '6.4.0'
+
+binutilsver = '2.28'
+versionsuffix = '-%s' % binutilsver
+
+homepage = 'http://gcc.gnu.org/'
+
+description = """
+ The GNU Compiler Collection includes front ends for C, C++, Objective-C,
+ Fortran, Java, and Ada, as well as libraries for these languages (libstdc++,
+ libgcj,...).  [NOTE: This module does not include Objective-C, Java or Ada]
+"""
+
+toolchain = {'name': 'dummy', 'version': ''}
+
+dependencies = [
+    ('GCCcore', version),
+    # binutils built on top of GCCcore, which was built
+    # on top of (dummy-built) binutils
+    ('binutils', binutilsver, '', ('GCCcore', version)),
+]
+
+altroot = 'GCCcore'
+altversion = 'GCCcore'
+
+# this bundle serves as a compiler-only toolchain,
+# so it should be marked as compiler (important for HMNS)
+moduleclass = 'compiler'


### PR DESCRIPTION
This change is necessary because:

* GCC-6.4.0 required for toolchain

The issue is resolved in this commit by:

* adding GCC-6.4.0.eb

[Jira: INFRA-4134]

