### PR TITLE
INFRA-4835 Canvas and DotNet easyconfig

### DIFF
--- a/gelconfigs/c/Canvas/Canvas-1.28.0.eb
+++ b/gelconfigs/c/Canvas/Canvas-1.28.0.eb
@@ -5,16 +5,16 @@
 
 easyblock = 'Tarball'
 
-name = 'dotnet'
-version = '1.1.4'
+name = 'canvas'
+version = '1.28.0.272'
 
-homepage = 'https://github.com/dotnet/core'
-description = """Microsoft .NET Core"""
+homepage = 'https://github.com/Illumina/canvas'
+description = """Canvas From Illumina"""
 
 toolchain = {'name': 'dummy', 'version': ''}
 
-source_urls = ['https://download.microsoft.com/download/6/F/B/6FB4F9D2-699B-4A40-A674-B7FF41E0E4D2/']
-sources = ['%(name)s-ubuntu.16.04-x64.%(version)s.tar.gz']
+source_urls = ['https://github.com/Illumina/canvas/releases/download/']
+sources = ['%(version)s/%(name)s-1.28_x64.tar.gz'] # You need to adjust value here
 
 modloadmsg = "DotNet-Core Loaded"
 

--- a/gelconfigs/c/Canvas/Canvas-1.28.0.eb
+++ b/gelconfigs/c/Canvas/Canvas-1.28.0.eb
@@ -16,7 +16,7 @@ toolchain = {'name': 'dummy', 'version': ''}
 source_urls = ['https://github.com/Illumina/canvas/releases/download/']
 sources = ['%(version)s/%(name)s-1.28_x64.tar.gz'] # You need to adjust value here
 
-modloadmsg = "DotNet-Core Loaded"
+modloadmsg = "Canvas Loaded"
 
 sanity_check_paths = {
     'files': ["dotnet"],

--- a/gelconfigs/d/dotnet/dotnet-1.1.4.eb
+++ b/gelconfigs/d/dotnet/dotnet-1.1.4.eb
@@ -1,0 +1,28 @@
+https://download.microsoft.com/download/6/F/B/6FB4F9D2-699B-4A40-A674-B7FF41E0E4D2/dotnet-ubuntu.16.04-x64.1.1.4.tar.gz
+
+##
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+# Authors::   Josh Cullum <joshua.cullum@genomicsengland.co.uk> / Genomics England Ltd
+# License::   MIT/GPL
+
+easyblock = 'Tarball'
+
+name = 'dotnet'
+version = '1.1.4'
+
+homepage = 'https://github.com/dotnet/core'
+description = """Microsoft .NET Core"""
+
+toolchain = {'name': 'dummy', 'version': ''}
+
+source_urls = ['https://download.microsoft.com/download/6/F/B/6FB4F9D2-699B-4A40-A674-B7FF41E0E4D2/']
+sources = ['%(name)s-ubuntu.16.04-x64.%(version)s.tar.gz']
+
+modloadmsg = "DotNet-Core Loaded"
+
+sanity_check_paths = {
+    'files': ["dotnet"],
+    'dirs': [],
+}
+
+moduleclass = 'bio'

--- a/gelconfigs/p/picard/picard-2.15.0.eb
+++ b/gelconfigs/p/picard/picard-2.15.0.eb
@@ -1,0 +1,39 @@
+##
+#
+# 2.15.0:
+# Josh Cullum
+# Genomics England Ltd, Queen Mary University London
+#
+##
+
+easyblock = 'JAR'
+
+name = 'picard'
+version = '2.15.0'
+versionsuffix = '-Java-%(javaver)s'
+
+homepage = 'http://sourceforge.net/projects/picard'
+description = """A set of tools (in Java) for working with next generation sequencing data in the BAM format."""
+
+toolchain = {'name': 'dummy', 'version': ''}
+
+source_urls = ['https://github.com/broadinstitute/picard/releases/download/%(version)s']
+sources = [{
+    'filename': '%(name)s-%(version)s.jar',
+    'download_filename': '%(name)s.jar',
+}]
+
+# checksums = ['ace0de725f7dbf3a1f621ac146e205b41bc872a0bdc700cf687124740fb60412']
+
+postinstallcmds = [' mv %(installdir)s/%(name)s-%(version)s.jar %(installdir)s/%(name)s.jar']
+
+dependencies = [('Java', '1.8.0_144')]
+
+sanity_check_paths = {
+    'files': ['picard.jar'],
+    'dirs': [],
+}
+
+modloadmsg = "To execute picard run: java -jar $EBROOTPICARD/%(name)s.jar"
+
+moduleclass = 'bio'


### PR DESCRIPTION
This change is necessary because:

* We need to install canvas and dotnet

The issue is resolved in this commit by:

* The easyconfigs for Canvas and Dotnet ready for build

[Jira: [INFRA-4835](https://jira.extge.co.uk/browse/INFRA-4835)]

