### PR TITLE
INFRA-4995 Update to point Java to our internal repo

### DIFF
--- a/gelconfigs/j/Java/Java-1.8.0_131.eb
+++ b/gelconfigs/j/Java/Java-1.8.0_131.eb
@@ -1,5 +1,5 @@
 name = 'Java'
-version = '1.8.0_144'
+version = '1.8.0_131'
 
 homepage = 'http://java.com/'
 


### PR DESCRIPTION
This change is necessary because:

* Look for Java tar.gz files within GEL Internal Repo
* Picard requires Java_8u144 to work

The issue is resolved in this commit by:

* Pointing the java recipes to look for source archive within our files repo
* Adds 8u131 

[Jira: [INFRA-4995](https://jira.extge.co.uk/browse/INFRA-4995)]

