### PR TITLE
INFRA-4959 Update to OpenMPI Toolchain + additional

### DIFF
--- a/gelconfigs/c/Canvas/Canvas-1.28.0.eb
+++ b/gelconfigs/c/Canvas/Canvas-1.28.0.eb
@@ -13,6 +13,10 @@ description = """Canvas From Illumina"""
 
 toolchain = {'name': 'dummy', 'version': ''}
 
+dependencies = {
+  ('dotnet', '1.1.4')
+}
+
 source_urls = ['https://github.com/Illumina/canvas/releases/download/']
 sources = ['%(version)s/%(name)s-1.28_x64.tar.gz'] # You need to adjust value here
 

--- a/gelconfigs/d/dotnet/dotnet-1.1.4.eb
+++ b/gelconfigs/d/dotnet/dotnet-1.1.4.eb
@@ -16,11 +16,19 @@ toolchain = {'name': 'dummy', 'version': ''}
 source_urls = ['https://download.microsoft.com/download/6/F/B/6FB4F9D2-699B-4A40-A674-B7FF41E0E4D2/']
 sources = ['%(name)s-ubuntu.16.04-x64.%(version)s.tar.gz']
 
+dependencies = [
+  ('zlib', '1.2.11'),
+  ('cURL', '7.55.1'),
+]
+
+
 modloadmsg = "DotNet-Core Loaded"
 
 sanity_check_paths = {
     'files': ["dotnet"],
     'dirs': [],
 }
+
+modextrapaths = {'PATH': '.'}
 
 moduleclass = 'bio'

--- a/gelconfigs/o/OpenMPI/OpenMPI-3.0.0.eb
+++ b/gelconfigs/o/OpenMPI/OpenMPI-3.0.0.eb
@@ -32,7 +32,8 @@ osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
 #     'dirs': [],
 # }
 sanity_check_paths = {
-    'files': ["bin/ompi_info", "lib/libmpi.so", "include/mpif.h", "include/mpif-ext.h"]
+    'files': ['bin/ompi_info', 'lib/libmpi.so', 'include/mpif.h', 'include/mpif-ext.h'],
+    'dirs': [],
 }
 
 moduleclass = 'mpi'


### PR DESCRIPTION
This change is necessary because:

* Building toolchains with OpenMPI isnt' working
* Canvas has some dependencies

The issue is resolved in this commit by:

* removing sanity checks for OpenMPI
* Update the canvas and dotnet recipes with their dependencies

[Jira: [INFRA-4959](https://jira.extge.co.uk/browse/INFRA-4959)]

