### PR TITLE
INFRA-4959 Updates to make ToolChains work

### DIFF
--- a/gelconfigs/c/Canvas/Canvas-1.28.0.eb
+++ b/gelconfigs/c/Canvas/Canvas-1.28.0.eb
@@ -27,4 +27,8 @@ sanity_check_paths = {
     'dirs': [],
 }
 
+modaliases = {
+  ('canvas': 'dotnet ${root}/Canvas.dll $*')
+}
+
 moduleclass = 'bio'

--- a/gelconfigs/c/cURL/cURL-7.55.1.eb
+++ b/gelconfigs/c/cURL/cURL-7.55.1.eb
@@ -22,7 +22,7 @@ sources = [SOURCELOWER_TAR_GZ]
 checksums = ['09576ea5e66672648d83dce3af16d0cb294d4cba2b5d166ade39655c495f4a20']
 
 builddependencies = [
-    ('binutils', '2.28'),
+    ('binutils', '.2.28'),
 ]
 
 dependencies = [

--- a/gelconfigs/f/FFTW/FFTW-3.3.6.eb
+++ b/gelconfigs/f/FFTW/FFTW-3.3.6.eb
@@ -13,7 +13,7 @@ sources = ['fftw-%(version)s-pl2.tar.gz']
 checksums = ['927e481edbb32575397eb3d62535a856']
 
 dependencies = [
-    ('OpenMPI', '2.1.1'),
+    ('OpenMPI', '3.0.0'),
 ]
 
 # no quad precision, requires GCC v4.6 or higher

--- a/gelconfigs/f/foss/foss-2017b.eb
+++ b/gelconfigs/f/foss/foss-2017b.eb
@@ -17,7 +17,7 @@ gccver = '6.4.0'
 dependencies = [
     ('GCC', '6.4.0'),
     ('OpenMPI', '3.0.0'),
-    ('OpenBLAS', '0.2.20', '', ('GCCcore', '6.4.0')),
+    ('OpenBLAS', '0.2.20', '', ('GCC', '6.4.0')),
     ('FFTW', '3.3.6'),
     ('ScaLAPACK', '2.0.2', '', ('gompi', '2017b')),
 ]

--- a/gelconfigs/f/foss/foss-2017b.eb
+++ b/gelconfigs/f/foss/foss-2017b.eb
@@ -16,7 +16,7 @@ gccver = '6.4.0'
 # For binutils, stick to http://wiki.osdev.org/Cross-Compiler_Successful_Builds
 dependencies = [
     ('GCC', '6.4.0'),
-    ('OpenMPI', '2.1.1'),
+    ('OpenMPI', '3.0.0'),
     ('OpenBLAS', '0.2.20', '', ('GCCcore', '6.4.0')),
     ('FFTW', '3.3.6'),
     ('ScaLAPACK', '2.0.2', '', ('gompi', '2017b')),

--- a/gelconfigs/g/gompi/gompi-2017b.eb
+++ b/gelconfigs/g/gompi/gompi-2017b.eb
@@ -14,7 +14,7 @@ gccver = '6.4.0'
 # compiler toolchain dependencies
 dependencies = [
     ('GCC', gccver),  # includes both GCC
-    ('OpenMPI', '2.1.1'),
+    ('OpenMPI', '3.0.0'),
 ]
 
 moduleclass = 'toolchain'

--- a/gelconfigs/o/OpenBLAS/OpenBLAS-0.2.20-GCC-6.4.0.eb
+++ b/gelconfigs/o/OpenBLAS/OpenBLAS-0.2.20-GCC-6.4.0.eb
@@ -6,7 +6,7 @@ version = '0.2.20'
 homepage = 'http://xianyi.github.com/OpenBLAS/'
 description = "OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."
 
-toolchain = {'name': 'GCCcore', 'version': '6.4.0'}
+toolchain = {'name': 'GCC', 'version': '6.4.0'}
 
 large_src = 'large.tgz'
 timing_src = 'timing.tgz'

--- a/gelconfigs/o/OpenBLAS/OpenBLAS-0.2.20.eb
+++ b/gelconfigs/o/OpenBLAS/OpenBLAS-0.2.20.eb
@@ -6,7 +6,7 @@ version = '0.2.20'
 homepage = 'http://xianyi.github.com/OpenBLAS/'
 description = "OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."
 
-toolchain = {'name': 'dummy', 'version': ''}
+toolchain = {'name': 'GCC', 'version': '6.4.0'}
 
 large_src = 'large.tgz'
 timing_src = 'timing.tgz'

--- a/gelconfigs/o/OpenMPI/OpenMPI-2.1.1.eb
+++ b/gelconfigs/o/OpenMPI/OpenMPI-2.1.1.eb
@@ -6,7 +6,7 @@ version = '2.1.1'
 homepage = 'http://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
-toolchain = {'name': 'dummy', 'version': ''}
+toolchain = {'name': 'GCC', 'version': '6.4.0'}
 
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]

--- a/gelconfigs/o/OpenMPI/OpenMPI-2.1.2.eb
+++ b/gelconfigs/o/OpenMPI/OpenMPI-2.1.2.eb
@@ -6,7 +6,7 @@ version = '2.1.2'
 homepage = 'http://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
-toolchain = {'name': 'dummy', 'version': ''}
+toolchain = {'name': 'GCC', 'version': '6.4.0'}
 
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]

--- a/gelconfigs/o/OpenMPI/OpenMPI-3.0.0.eb
+++ b/gelconfigs/o/OpenMPI/OpenMPI-3.0.0.eb
@@ -6,7 +6,7 @@ version = '3.0.0'
 homepage = 'http://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
-toolchain = {'name': 'dummy', 'version': ''}
+toolchain = {'name': 'GCC', 'version': '6.4.0'}
 
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]

--- a/gelconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2017b.eb
+++ b/gelconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2017b.eb
@@ -13,7 +13,7 @@ sources = [SOURCELOWER_TGZ]
 checksums = ['0c74aeae690fe5ee4db7926f49c5d0bb69ce09eea75beb915e00bba07530395c']
 
 dependencies = [
-  ('OpenBLAS', '0.2.20'),
+  ('OpenBLAS', '0.2.20', '', ('GCC', '6.4.0')),
   ('OpenMPI', '3.0.0'),
 ]
 

--- a/gelconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2017b.eb
+++ b/gelconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2017b.eb
@@ -14,7 +14,7 @@ checksums = ['0c74aeae690fe5ee4db7926f49c5d0bb69ce09eea75beb915e00bba07530395c']
 
 dependencies = [
   ('OpenBLAS', '0.2.20'),
-  ('OpenMPI', '2.1.1'),
+  ('OpenMPI', '3.0.0'),
 ]
 
 # parallel build tends to fail, so disabling it

--- a/gelconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2.eb
+++ b/gelconfigs/s/ScaLAPACK/ScaLAPACK-2.0.2.eb
@@ -14,7 +14,7 @@ checksums = ['0c74aeae690fe5ee4db7926f49c5d0bb69ce09eea75beb915e00bba07530395c']
 
 dependencies = [
   ('OpenBLAS', '0.2.20'),
-  ('OpenMPI', '2.1.1'),
+  ('OpenMPI', '3.0.0'),
 ]
 
 # parallel build tends to fail, so disabling it


### PR DESCRIPTION
This change is necessary because:

* OpenMPI hasn't built correctly and requires GCC/6.4.0

The issue is resolved in this commit by:

* Adding GCC/6.4.0 to OpenMPI and update OpenMPI/3.0.0

[Jira: [INFRA-4959](https://jira.extge.co.uk/browse/INFRA-4959)]

