### PR TITLE
INFRA-4959 OpenMPI Push back to dummy toolchain, but to load GCC on build.

### DIFF
--- a/gelconfigs/o/OpenMPI/OpenMPI-3.0.0.eb
+++ b/gelconfigs/o/OpenMPI/OpenMPI-3.0.0.eb
@@ -6,11 +6,12 @@ version = '3.0.0'
 homepage = 'http://www.open-mpi.org/'
 description = """The Open MPI Project is an open source MPI-2 implementation."""
 
-toolchain = {'name': 'GCC', 'version': '6.4.0'}
+toolchain = {'name': 'dummy', 'version': ''}
 
 source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
 sources = [SOURCELOWER_TAR_GZ]
 
+builddependencies = [('GCC', '6.4.0')]
 dependencies = [('hwloc', '.1.11.7')]
 
 configopts = '--enable-shared --enable-mpi-thread-multiple --with-verbs '


### PR DESCRIPTION
This change is necessary because:

* OpenMPI fails to build correctly on standard dummy toolchain, 

The issue is resolved in this commit by:

* Adding GCC to build dependencies and removing from toolchain

[Jira: [INFRA-4959](https://jira.extge.co.uk/browse/INFRA-4959)]

