### PR TITLE
INFRA-4959 remove hidden dependency from OpenMPI

### DIFF
--- a/gelconfigs/o/OpenMPI/OpenMPI-3.0.0.eb
+++ b/gelconfigs/o/OpenMPI/OpenMPI-3.0.0.eb
@@ -12,7 +12,7 @@ source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/d
 sources = [SOURCELOWER_TAR_GZ]
 
 builddependencies = [('GCC', '6.4.0')]
-dependencies = [('hwloc', '.1.11.7')]
+dependencies = [('hwloc', '1.11.7')]
 
 configopts = '--enable-shared --enable-mpi-thread-multiple --with-verbs '
 configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path


### PR DESCRIPTION
This change is necessary because:

* OpenMPI complains about dependency for hwloc, when using .1.11.7

The issue is resolved in this commit by:

* remove the dot.

[Jira: [INFRA-4959](https://jira.extge.co.uk/browse/INFRA-4959)]

