### PR TITLE
INFRA-5251 Adding picard-2.10 to our tools builder

### DIFF
--- a/gelconfigs/p/picard/picard-2.10.0.eb
+++ b/gelconfigs/p/picard/picard-2.10.0.eb
@@ -1,0 +1,38 @@
+##
+#
+# 2.10.0:
+# Ramez Saour
+# Genomics England Ltd, Queen Mary University London
+#
+##
+
+easyblock = 'JAR'
+
+name = 'picard'
+version = '2.10.0'
+
+homepage = 'http://sourceforge.net/projects/picard'
+description = """A set of tools (in Java) for working with next generation sequencing data in the BAM format."""
+
+toolchain = {'name': 'dummy', 'version': ''}
+
+source_urls = ['https://github.com/broadinstitute/picard/releases/download/%(version)s']
+sources = [{
+    'filename': '%(name)s-%(version)s.jar',
+    'download_filename': '%(name)s.jar',
+}]
+
+# checksums = ['ace0de725f7dbf3a1f621ac146e205b41bc872a0bdc700cf687124740fb60412']
+
+postinstallcmds = [' mv %(installdir)s/%(name)s-%(version)s.jar %(installdir)s/%(name)s.jar']
+
+dependencies = [('Java', '1.8.0_144')]
+
+sanity_check_paths = {
+    'files': ['picard.jar'],
+    'dirs': [],
+}
+
+modloadmsg = "To execute picard run: java -jar $EBROOTPICARD/%(name)s.jar"
+
+moduleclass = 'bio'


### PR DESCRIPTION
This change is necessary because:

* Adding new module to our build picard 2.10
The issue is resolved in this commit by:

* picard 2.10 required 

[Jira: INFRA-5251] (https://jira.extge.co.uk/browse/INFRA-5251)

