### PR TITLE
INFRA-5251 installing python.3.4.0

### DIFF
--- a/gelconfigs/p/Python/Python-3.4.0.eb
+++ b/gelconfigs/p/Python/Python-3.4.0.eb
@@ -1,0 +1,133 @@
+name = 'Python'
+version = '3.4.0'
+
+homepage = 'http://python.org/'
+description = """Python is a programming language that lets you work more quickly and integrate your systems
+ more effectively."""
+
+toolchain = {'name': 'foss', 'version': '2017b'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
+sources = [SOURCE_TGZ]
+
+# python needs bzip2 to build the bz2 package
+dependencies = [
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.11'),
+    ('libreadline', '7.0'),
+    ('ncurses', '6.0'),
+    ('SQLite', '3.17.0'),
+    ('GMP', '6.1.2'),
+    ('XZ', '5.2.3'),
+    ('libffi', '3.2.1'),
+    # OS dependency should be preferred if the os version is more recent then this version,
+    # it's nice to have an up to date openssl for security reasons
+    # ('OpenSSL', '1.0.2k'),
+]
+
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
+
+# order is important!
+# package versions updated May 28th 2015
+exts_list = [
+    # note: more recent versions of setuptools (v34.x) can not be installed from source anymore,
+    # see https://github.com/pypa/setuptools/issues/980
+    ('setuptools', '33.1.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
+        'source_tmpl': '%(name)s-%(version)s.zip',
+    }),
+    ('pip', '9.0.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
+    }),
+    ('nose', '1.3.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
+    }),
+    ('numpy', '1.13.3', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/numpy'],
+        'source_tmpl': '%(name)s-%(version)s.zip',
+        # 'patches': ['numpy-1.12.0-mkl.patch'],
+    }),
+    ('scipy', '1.0.0', {
+        'source_urls': ['https://github.com/scipy/scipy/releases/download/v%(version)s/'],
+        'source_tmpl': '%(name)s-%(version)s.tar.gz',
+    }),
+    ('blist', '1.3.6', {
+        'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
+    }),
+    ('mpi4py', '2.0.0', {
+        'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
+    }),
+    ('paycheck', '1.0.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
+        'patches': [
+            'paycheck-1.0.2_setup-open-README-utf8.patch',
+        ],
+    }),
+    ('pbr', '2.0.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
+    }),
+    ('lockfile', '0.12.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/l/lockfile/'],
+    }),
+    ('Cython', '0.25.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cython/'],
+    }),
+    ('six', '1.10.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/six/'],
+    }),
+    ('dateutil', '2.6.0', {
+        'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
+    }),
+    ('deap', '1.0.2', {
+        'source_tmpl': '%(name)s-%(version)s.post2.tar.gz',
+        'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],
+        'patches': [
+            'deap-1.0.2_setup-open-README-utf8.patch',
+        ],
+    }),
+    ('decorator', '4.0.11', {
+        'source_urls': ['https://pypi.python.org/packages/source/d/decorator/'],
+    }),
+    ('arff', '2.1.0', {
+        'source_tmpl': 'liac-%(name)s-%(version)s.zip',
+        'source_urls': ['https://pypi.python.org/packages/source/l/liac-arff/'],
+    }),
+    ('pycrypto', '2.6.1', {
+        'modulename': 'Crypto',
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
+    }),
+    ('ecdsa', '0.13', {
+        'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],
+    }),
+    ('cryptography', '1.8.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cryptography/'],
+    }),
+    ('paramiko', '2.1.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/paramiko/'],
+    }),
+    ('pyparsing', '2.2.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pyparsing/'],
+    }),
+    ('netifaces', '0.10.5', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/netifaces'],
+    }),
+    ('netaddr', '0.7.19', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/netaddr'],
+    }),
+    ('pandas', '0.19.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pandas'],
+    }),
+    ('virtualenv', '15.1.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/v/virtualenv'],
+    }),
+    ('docopt', '0.6.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/d/docopt'],
+    }),
+    ('joblib', '0.11', {
+        'source_urls': ['https://pypi.python.org/packages/source/j/joblib'],
+    }),
+]
+
+moduleclass = 'lang'


### PR DESCRIPTION
This change is necessary because:

* Installing Python 3.4.0 to our tools builders.

The issue is resolved in this commit by:

* module required for build and testing

[Jira: INFRA-5251](https://jira.extge.co.uk/browse/INFRA-5251)

