### PR TITLE
INFRA-5251 rename the application tools with inline with other tools …

### DIFF
--- a/gelconfigs/b/bedtools/bedtools-2.26.0.eb
+++ b/gelconfigs/b/bedtools/bedtools-2.26.0.eb
@@ -7,7 +7,7 @@
 
 easyblock = 'MakeCp'
 
-name = 'BEDTools'
+name = 'bedtools'
 version = '2.26.0'
 
 homepage = "https://github.com/arq5x/bedtools2"


### PR DESCRIPTION
This change is necessary because:

* rename bedtools file and application to inline with other tools
The issue is resolved in this commit by:

* modify the file and application tools to lower case.

[Jira: INFRA-5251] (https://jira.extge.co.uk/browse/INFRA-5251)

