### PR TITLE
INFRA-5999-easybuild recipe(s) for Platypus build

### DIFF
--- a/gelconfigs/h/HTSlib/HTSlib-1.3-foss-2016a.eb
+++ b/gelconfigs/h/HTSlib/HTSlib-1.3-foss-2016a.eb
@@ -1,0 +1,27 @@
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+# Author: Pablo Escobar Lopez
+# Swiss Institute of Bioinformatics
+# Biozentrum - University of Basel
+
+easyblock = 'ConfigureMake'
+
+name = 'HTSlib'
+version = '1.3'
+
+homepage = "http://www.htslib.org/"
+description = """A C library for reading/writing high-throughput sequencing data.
+ This package includes the utilities bgzip and tabix"""
+
+toolchain = {'name': 'foss', 'version': '2016a'}
+
+source_urls = ['https://github.com/samtools/%(namelower)s/releases/download/%(version)s/']
+sources = [SOURCELOWER_TAR_BZ2]
+
+dependencies = [('zlib', '1.2.8')]
+
+sanity_check_paths = {
+    'files': ["bin/bgzip", "bin/tabix", "lib/libhts.%s" % SHLIB_EXT],
+    'dirs': [],
+}
+
+moduleclass = 'bio'

--- a/gelconfigs/h/HTSlib/HTSlib-1.3-intel-2016a.eb
+++ b/gelconfigs/h/HTSlib/HTSlib-1.3-intel-2016a.eb
@@ -1,0 +1,27 @@
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+# Author: Pablo Escobar Lopez
+# Swiss Institute of Bioinformatics
+# Biozentrum - University of Basel
+
+easyblock = 'ConfigureMake'
+
+name = 'HTSlib'
+version = '1.3'
+
+homepage = "http://www.htslib.org/"
+description = """A C library for reading/writing high-throughput sequencing data.
+ This package includes the utilities bgzip and tabix"""
+
+toolchain = {'name': 'intel', 'version': '2016a'}
+
+source_urls = ['https://github.com/samtools/%(namelower)s/releases/download/%(version)s/']
+sources = [SOURCELOWER_TAR_BZ2]
+
+dependencies = [('zlib', '1.2.8')]
+
+sanity_check_paths = {
+    'files': ["bin/bgzip", "bin/tabix", "lib/libhts.%s" % SHLIB_EXT],
+    'dirs': [],
+}
+
+moduleclass = 'bio'

--- a/gelconfigs/p/Python/Python-2.7.11-GCC-4.9.3-2.25-bare.eb
+++ b/gelconfigs/p/Python/Python-2.7.11-GCC-4.9.3-2.25-bare.eb
@@ -1,0 +1,33 @@
+name = 'Python'
+version = '2.7.11'
+versionsuffix = '-bare'
+
+homepage = 'http://python.org/'
+description = """Python is a programming language that lets you work more quickly and integrate your systems
+ more effectively."""
+
+toolchain = {'name': 'GCC', 'version': '4.9.3-2.25'}
+toolchainopts = {'pic': True, 'opt': True, 'optarch': True}
+
+source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
+sources = [SOURCE_TGZ]
+
+# python needs bzip2 to build the bz2 package
+dependencies = [
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.8'),
+    ('libreadline', '6.3', '', ('GCCcore', '4.9.3')),
+    ('ncurses', '6.0', '', ('GCCcore', '4.9.3')),
+    ('SQLite', '3.9.2'),
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
+    # OS dependency should be preferred if the os version is more recent then this version,
+    # it's nice to have an up to date openssl for security reasons
+    # ('OpenSSL', '1.0.1q'),
+]
+
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
+
+# bare installation: no extensions included
+exts_list = []
+
+moduleclass = 'lang'

--- a/gelconfigs/p/Python/Python-2.7.11-foss-2015a.eb
+++ b/gelconfigs/p/Python/Python-2.7.11-foss-2015a.eb
@@ -1,0 +1,137 @@
+name = 'Python'
+version = '2.7.11'
+
+homepage = 'http://python.org/'
+description = """Python is a programming language that lets you work more quickly and integrate your systems
+ more effectively."""
+
+toolchain = {'name': 'foss', 'version': '2015a'}
+toolchainopts = {'pic': True, 'opt': True, 'optarch': True}
+
+numpyversion = '1.10.1'
+scipyversion = '0.16.1'
+
+source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
+sources = [SOURCE_TGZ]
+
+# python needs bzip2 to build the bz2 package
+dependencies = [
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.8'),
+    ('libreadline', '6.3'),
+    ('ncurses', '5.9'),
+    ('SQLite', '3.10.0'),
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
+    ('GMP', '6.1.0'),  # required for pycrypto
+    # OS dependency should be preferred if the os version is more recent then this version,
+    # it's nice to have an up to date openssl for security reasons
+    # ('OpenSSL', '1.0.1q'),
+]
+
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
+
+# order is important!
+# package versions updated May 28th 2015
+exts_list = [
+    ('setuptools', '18.7.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
+    }),
+    ('pip', '7.1.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
+    }),
+    ('nose', '1.3.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
+    }),
+    ('numpy', numpyversion, {
+        'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
+        'patches': ['numpy-1.8.0-mkl.patch'],
+    }),
+    ('scipy', scipyversion, {
+        'source_urls': [('http://sourceforge.net/projects/scipy/files/scipy/%s' % scipyversion, 'download')],
+    }),
+    ('blist', '1.3.6', {
+        'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
+    }),
+    ('mpi4py', '1.3.1', {
+        'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
+    }),
+    ('paycheck', '1.0.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
+    }),
+    ('argparse', '1.4.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/a/argparse/'],
+    }),
+    ('pbr', '1.8.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
+    }),
+    ('lockfile', '0.12.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/l/lockfile/'],
+    }),
+    ('Cython', '0.23.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cython/'],
+    }),
+    ('six', '1.10.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/six/'],
+    }),
+    ('dateutil', '2.4.2', {
+        'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
+    }),
+    ('deap', '1.0.2', {
+        'source_tmpl': '%(name)s-%(version)s.post2.tar.gz',
+        'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],
+    }),
+    ('decorator', '4.0.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/d/decorator/'],
+    }),
+    ('arff', '2.1.0', {
+        'source_tmpl': 'liac-%(name)s-%(version)s.zip',
+        'source_urls': ['https://pypi.python.org/packages/source/l/liac-arff/'],
+    }),
+    ('pycrypto', '2.6.1', {
+        'modulename': 'Crypto',
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
+    }),
+    ('ecdsa', '0.13', {
+        'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],
+    }),
+    ('paramiko', '1.16.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/paramiko/'],
+    }),
+    ('pyparsing', '2.0.6', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pyparsing/'],
+    }),
+    ('netifaces', '0.10.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/netifaces'],
+    }),
+    ('netaddr', '0.7.18', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/netaddr'],
+    }),
+    ('funcsigs', '0.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/f/funcsigs'],
+    }),
+    ('mock', '1.3.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/m/mock'],
+    }),
+    ('pytz', '2015.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pytz'],
+    }),
+    ('pandas', '0.17.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pandas'],
+    }),
+    ('enum34', '1.1.2', {
+        'modulename': 'enum',
+        'source_urls': ['https://pypi.python.org/packages/source/e/enum34'],
+    }),
+    ('bitstring', '3.1.3', {
+        # grab tarball from GitHub rather than PyPi since 3.1.3 release on PyPi disappeared;
+        # cfr. https://github.com/scott-griffiths/bitstring/issues/159
+        'source_tmpl': '%(name)s-%(version)s.tar.gz',
+        'source_urls': ['https://github.com/scott-griffiths/bitstring/archive/'],
+    }),
+    ('virtualenv', '14.0.5', {
+        'source_urls': ['https://pypi.python.org/packages/source/v/virtualenv'],
+    }),
+]
+
+moduleclass = 'lang'

--- a/gelconfigs/p/Python/Python-2.7.11-intel-2016.02-GCC-4.9.eb
+++ b/gelconfigs/p/Python/Python-2.7.11-intel-2016.02-GCC-4.9.eb
@@ -1,0 +1,140 @@
+name = 'Python'
+version = '2.7.11'
+
+homepage = 'http://python.org/'
+description = """Python is a programming language that lets you work more quickly and integrate your systems
+ more effectively."""
+
+toolchain = {'name': 'intel', 'version': '2016.02-GCC-4.9'}
+toolchainopts = {'pic': True, 'opt': True, 'optarch': True}
+
+numpyversion = '1.10.1'
+scipyversion = '0.16.1'
+
+source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
+sources = [SOURCE_TGZ]
+
+# python needs bzip2 to build the bz2 package
+dependencies = [
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.8'),
+    ('libreadline', '6.3'),
+    ('ncurses', '6.0'),
+    ('SQLite', '3.9.2'),
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
+    ('GMP', '6.1.0'),
+    # OS dependency should be preferred if the os version is more recent then this version,
+    # it's nice to have an up to date openssl for security reasons
+    # ('OpenSSL', '1.0.1q'),
+]
+
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
+
+# order is important!
+# package versions updated May 28th 2015
+exts_list = [
+    ('setuptools', '18.7.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
+    }),
+    ('pip', '7.1.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
+    }),
+    ('nose', '1.3.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
+    }),
+    ('numpy', numpyversion, {
+        'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
+        'patches': [
+            'numpy-1.8.0-mkl.patch',
+            'numpy-%s-sse42.patch' % numpyversion,
+        ],
+    }),
+    ('scipy', scipyversion, {
+        'source_urls': [('http://sourceforge.net/projects/scipy/files/scipy/%s' % scipyversion, 'download')],
+    }),
+    ('blist', '1.3.6', {
+        'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
+    }),
+    ('mpi4py', '1.3.1', {
+        'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
+    }),
+    ('paycheck', '1.0.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
+    }),
+    ('argparse', '1.4.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/a/argparse/'],
+    }),
+    ('pbr', '1.8.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
+    }),
+    ('lockfile', '0.12.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/l/lockfile/'],
+    }),
+    ('Cython', '0.23.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cython/'],
+    }),
+    ('six', '1.10.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/six/'],
+    }),
+    ('dateutil', '2.4.2', {
+        'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
+    }),
+    ('deap', '1.0.2', {
+        'source_tmpl': '%(name)s-%(version)s.post2.tar.gz',
+        'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],
+    }),
+    ('decorator', '4.0.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/d/decorator/'],
+    }),
+    ('arff', '2.1.0', {
+        'source_tmpl': 'liac-%(name)s-%(version)s.zip',
+        'source_urls': ['https://pypi.python.org/packages/source/l/liac-arff/'],
+    }),
+    ('pycrypto', '2.6.1', {
+        'modulename': 'Crypto',
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
+    }),
+    ('ecdsa', '0.13', {
+        'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],
+    }),
+    ('paramiko', '1.16.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/paramiko/'],
+    }),
+    ('pyparsing', '2.0.6', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pyparsing/'],
+    }),
+    ('netifaces', '0.10.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/netifaces'],
+    }),
+    ('netaddr', '0.7.18', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/netaddr'],
+    }),
+    ('funcsigs', '0.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/f/funcsigs'],
+    }),
+    ('mock', '1.3.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/m/mock'],
+    }),
+    ('pytz', '2015.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pytz'],
+    }),
+    ('pandas', '0.17.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pandas'],
+    }),
+    ('enum34', '1.1.2', {
+        'modulename': 'enum',
+        'source_urls': ['https://pypi.python.org/packages/source/e/enum34'],
+    }),
+    ('bitstring', '3.1.3', {
+        # grab tarball from GitHub rather than PyPi since 3.1.3 release on PyPi disappeared;
+        # cfr. https://github.com/scott-griffiths/bitstring/issues/159
+        'source_tmpl': '%(name)s-%(version)s.tar.gz',
+        'source_urls': ['https://github.com/scott-griffiths/bitstring/archive/'],
+    }),
+    ('virtualenv', '14.0.5', {
+        'source_urls': ['https://pypi.python.org/packages/source/v/virtualenv'],
+    }),
+]
+
+moduleclass = 'lang'


### PR DESCRIPTION
This changes is required 
  - to enable automatic dependencies detection with Platypus recipe with --robot build option

The issue is resolved in this commit by:
  - adding dependencies recipes from easybuild global configs to gelconfigs  