### PR TITLE
INFRA-10715 Added Muscle to easybuild repository

### DIFF
--- a/gelconfigs/m/MUSCLE/MUSCLE-3.8.31-foss-2017b.eb
+++ b/gelconfigs/m/MUSCLE/MUSCLE-3.8.31-foss-2017b.eb
@@ -1,0 +1,31 @@
+easyblock = 'MakeCp'
+
+name = 'MUSCLE'
+version = '3.8.31'
+
+homepage = 'http://drive5.com/muscle/'
+description = """ MUSCLE is one of the best-performing multiple alignment programs
+ according to published benchmark tests, with accuracy and speed that are consistently
+ better than CLUSTALW. MUSCLE can align hundreds of sequences in seconds. Most users
+ learn everything they need to know about MUSCLE in a few minutes-only a handful of
+ command-line options are needed to perform common alignment tasks."""
+
+toolchain = {'name': 'foss', 'version': '2017b'}
+
+source_urls = ['http://www.drive5.com/muscle/downloads%(version)s/']
+sources = ['%(namelower)s%(version)s_src.tar.gz']
+patches = ['MUSCLE-%(version)s_fix-mk-hardcoding.patch']
+checksums = [
+    '43c5966a82133bd7da5921e8142f2f592c2b5f53d802f0527a2801783af809ad',  # muscle3.8.31_src.tar.gz
+    'e108d1cc2d394236f839facc1304ff96c0e11f7fdd6d2444761808ec860cd58a',  # MUSCLE-3.8.31_fix-mk-hardcoding.patch
+]
+
+files_to_copy = [
+    (["muscle"], 'bin')]
+
+sanity_check_paths = {
+    'files': ["bin/muscle"],
+    'dirs': [],
+}
+
+moduleclass = 'bio'


### PR DESCRIPTION
This change is necessary because:
 
* HPC Tool Muscle needed to be installed
 
The issue is resolved in this commit by:
 
* Added Muscle to easybuild repository 
 
[Jira: [INFRA-10715](https://jira.extge.co.uk/browse/INFRA-10715)]