### PR TITLE
INFRA-10925 Added updated EasyBuild version recipe

### DIFF
--- a/easybuild/easyconfigs/e/EasyBuild/EasyBuild-3.6.1.eb
+++ b/easybuild/easyconfigs/e/EasyBuild/EasyBuild-3.6.1.eb
@@ -1,0 +1,45 @@
+easyblock = 'EB_EasyBuildMeta'
+
+name = 'EasyBuild'
+version = '3.6.1'
+
+homepage = 'https://easybuilders.github.io/easybuild'
+description = """EasyBuild is a software build and installation framework
+ written in Python that allows you to install software in a structured,
+ repeatable and robust way."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+source_urls = [
+    # vsc-install
+    'https://files.pythonhosted.org/packages/b5/2d/ba03794a9f710f5c65d0a6d296f099cd68581c9a6f78c1de2268da18fdb0/',
+    # vsc-base
+    'https://files.pythonhosted.org/packages/40/38/26e68ec85182a15469241cb78c97c3815b7923ff2f5a80825fed00037173/',
+    # easybuild-framework
+    'https://files.pythonhosted.org/packages/82/58/9377d0a5ed07dad637069b63706f9457644b526f0aa308d0692b6b34ff5b/',
+    # easybuild-easyblocks
+    'https://files.pythonhosted.org/packages/6a/9f/67a9255710227089bbce98753ef5c89c2afe69883d0339fb321b2148c056/',
+    # easybuild-easyconfigs
+    'https://files.pythonhosted.org/packages/fd/b4/c6f4655ebd0178e4aa9181c0d772c4244d378b18b90905f972f21ebc3448/',
+]
+sources = [
+    'vsc-install-0.11.1.tar.gz',
+    'vsc-base-2.7.2.tar.gz',
+    'easybuild-framework-%(version)s.tar.gz',
+    'easybuild-easyblocks-%(version)s.tar.gz',
+    'easybuild-easyconfigs-%(version)s.tar.gz',
+]
+checksums = [
+    'afbec5532f9f692c49fbefe8656975547b515eb8eb01c6ba8b85dd7af07cc1f4',  # vsc-install-0.11.1.tar.gz
+    'ba254b42ba8f8127d7af16f61182089cab750aff8eda3ae23858cf2fa03129ac',  # vsc-base-2.7.2.tar.gz
+    'edcbb02dcb1f2272199e2c10dbcc36a0003fe5d5941511e4e9f74ad742507b7a',  # easybuild-framework-3.6.1.tar.gz
+    '9f592214a190894890bdca5eaa84a9a0f5d9155e610a75c901f46709a87cac1b',  # easybuild-easyblocks-3.6.1.tar.gz
+    'e296a0992f5177cd72549b07da4019446cba44a88e891ac8535d6d47d0ab72f1',  # easybuild-easyconfigs-3.6.1.tar.gz
+]
+
+# order matters a lot, to avoid having dependencies auto-resolved (--no-deps easy_install option doesn't work?)
+# EasyBuild is a (set of) Python packages, so it depends on Python
+# usually, we want to use the system Python, so no actual Python dependency is listed
+allow_system_deps = [('Python', SYS_PYTHON_VERSION)]
+
+moduleclass = 'tools'


### PR DESCRIPTION
This change is necessary because:
 
* The current EasyBuild version 3.5.0 is outdated
 
The issue is resolved in this commit by:
 
* Added recipe for EasyBuild version 3.6.1
 
[Jira: [INFRA-10925](https://jira.extge.co.uk/browse/INFRA-10925)]