### PR TITLE
INFRA-11107 - Added updated GCCcore recipe to v8.1.0

### DIFF
--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-8.1.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-8.1.0.eb
@@ -1,0 +1,51 @@
+easyblock = 'EB_GCC'
+
+name = 'GCCcore'
+version = '8.1.0'
+
+homepage = 'http://gcc.gnu.org/'
+description = """The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Java, and Ada,
+ as well as libraries for these languages (libstdc++, libgcj,...)."""
+
+toolchain = {'name': 'dummy', 'version': ''}
+
+mpfr_version = '4.0.1'
+
+source_urls = [
+    'http://ftpmirror.gnu.org/gnu/gcc/gcc-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/mpc',  # idem for MPC
+    'ftp://gcc.gnu.org/pub/gcc/infrastructure/',  # GCC dependencies
+    'http://gcc.cybermirror.org/infrastructure/',  # HTTP mirror for GCC dependencies
+    'http://isl.gforge.inria.fr/',  # original HTTP source for ISL
+]
+sources = [
+    'gcc-%(version)s.tar.gz',
+    'gmp-6.1.2.tar.bz2',
+    'mpfr-%s.tar.bz2' % mpfr_version,
+    'mpc-1.1.0.tar.gz',
+    'isl-0.19.tar.bz2',
+]
+patches = [
+    'GCCcore-6.2.0-fix-find-isl.patch',
+]
+checksums = [
+    'af300723841062db6ae24e38e61aaf4fbf3f6e5d9fd3bf60ebbdbf95db4e9f09',  # gcc-8.1.0.tar.gz
+    '5275bb04f4863a13516b2f39392ac5e272f5e1bb8057b18aec1c9b79d73d8fb2',  # gmp-6.1.2.tar.bz2
+    'a4d97610ba8579d380b384b225187c250ef88cfe1d5e7226b89519374209b86b',  # mpfr-4.0.1.tar.bz2
+    '6985c538143c1208dcb1ac42cedad6ff52e267b47e5f970183a3e75125b43c2e',  # mpc-1.1.0.tar.gz
+    'd59726f34f7852a081fbd3defd1ab2136f174110fc2e0c8d10bb122173fa9ed8',  # isl-0.19.tar.bz2
+    '5ad909606d17d851c6ad629b4fddb6c1621844218b8d139fed18c502a7696c68',  # GCCcore-6.2.0-fix-find-isl.patch
+]
+
+builddependencies = [
+    ('M4', '1.4.18'),
+    ('binutils', '2.30'),
+]
+
+languages = ['c', 'c++', 'fortran']
+
+withisl = True
+
+moduleclass = 'compiler'


### PR DESCRIPTION
This change is necessary because:
 
* Older versions of GCCcore have static binutils libraries which are causing issues with HPC tools installation
 
The issue is resolved in this commit by:
 
* Updated GCCcore recipe version to v8.1.0
 
[Jira: [INFRA-11107](https://jira.extge.co.uk/browse/INFRA-11107)]