### PR TITLE
INFRA-11107 Added binutils for GCCcore-8.1.0

### DIFF
--- a/easybuild/easyconfigs/b/Bison/Bison-3.0.4-GCCcore-8.1.0.eb
+++ b/easybuild/easyconfigs/b/Bison/Bison-3.0.4-GCCcore-8.1.0.eb
@@ -1,0 +1,28 @@
+easyblock = 'ConfigureMake'
+
+name = 'Bison'
+version = '3.0.4'
+
+homepage = 'http://www.gnu.org/software/bison'
+description = """Bison is a general-purpose parser generator that converts an annotated context-free grammar
+ into a deterministic LR or generalized LR (GLR) parser employing LALR(1) parser tables."""
+
+toolchain = {'name': 'GCCcore', 'version': '8.1.0'}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['b67fd2daae7a64b5ba862c66c07c1addb9e6b1b05c5f2049392cfd8a2172952e']
+
+builddependencies = [
+    ('M4', '1.4.18'),
+    # use same binutils version that was used when building GCCcore toolchain
+    ('binutils', '2.30', '', True),
+]
+
+
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in ['bison', 'yacc']] + [('lib/liby.a', 'lib64/liby.a')],
+    'dirs': [],
+}
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/b/binutils/binutils-2.30-GCCcore-8.1.0.eb
+++ b/easybuild/easyconfigs/b/binutils/binutils-2.30-GCCcore-8.1.0.eb
@@ -1,0 +1,26 @@
+name = 'binutils'
+version = '2.30'
+
+homepage = 'http://directory.fsf.org/project/binutils/'
+description = "binutils: GNU binary utilities"
+
+toolchain = {'name': 'GCCcore', 'version': '8.1.0'}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCE_TAR_GZ]
+patches = ['binutils-%(version)s_fix-assertion-fail-elf.patch']
+checksums = [
+    '8c3850195d1c093d290a716e20ebcaa72eda32abf5e3d8611154b39cff79e9ea',  # binutils-2.30.tar.gz
+    '7a661190c973287642296dd9fb30ff45dc26ae2138f7761cd8362f7e412ff5ab',  # binutils-2.30_fix-assertion-fail-elf.patch
+]
+
+builddependencies = [
+    ('flex', '2.6.4'),
+    ('Bison', '3.0.4'),
+    # zlib required, but being linked in statically, so not a runtime dep
+    ('zlib', '1.2.11'),
+    # use same binutils version that was used when building GCC toolchain, to 'bootstrap' this binutils
+    ('binutils', version, '', True)
+]
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-8.1.0.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-8.1.0.eb
@@ -1,0 +1,34 @@
+name = 'flex'
+version = '2.6.4'
+
+homepage = 'http://flex.sourceforge.net/'
+
+description = """
+ Flex (Fast Lexical Analyzer) is a tool for generating scanners. A scanner, 
+ sometimes called a tokenizer, is a program which recognizes lexical patterns
+ in text.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '8.1.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/westes/flex/releases/download/v%(version)s/']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['e87aae032bf07c26f85ac0ed3250998c37621d95f8bd748b31f15b33c45ee995']
+
+builddependencies = [
+    ('Bison', '3.0.4'),
+    ('help2man', '1.47.6'),
+    # use same binutils version that was used when building GCC toolchain
+    ('binutils', '2.30', '', True),
+]
+
+dependencies = [
+    ('M4', '1.4.18'),
+]
+
+# glibc 2.26 requires _GNU_SOURCE defined to expose reallocarray in the correct
+# header, see https://github.com/westes/flex/issues/241
+preconfigopts = 'export CPPFLAGS="$CPPFLAGS -D_GNU_SOURCE" && '
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/z/zlib/zlib-1.2.11-GCCcore-8.1.0.eb
+++ b/easybuild/easyconfigs/z/zlib/zlib-1.2.11-GCCcore-8.1.0.eb
@@ -1,0 +1,26 @@
+easyblock = 'ConfigureMake'
+
+name = 'zlib'
+version = '1.2.11'
+
+homepage = 'http://www.zlib.net/'
+description = """zlib is designed to be a free, general-purpose, legally unencumbered -- that is,
+ not covered by any patents -- lossless data-compression library for use on virtually any
+ computer hardware and operating system."""
+
+toolchain = {'name': 'GCCcore', 'version': '8.1.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://zlib.net/fossils']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1']
+
+# use same binutils version that was used when building GCC toolchain
+builddependencies = [('binutils', '2.30', '', True)]
+
+sanity_check_paths = {
+    'files': ['include/zconf.h', 'include/zlib.h', 'lib/libz.a', 'lib/libz.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+moduleclass = 'lib'


### PR DESCRIPTION
This change is necessary because:
 
* binutils are required for GCCcore-8.1.0
 
The issue is resolved in this commit by:
 
* Added easybuild recipes for binutils-2.30-GCCcore-8.1.0 and its dependencies
 
[Jira: [INFRA-11107](https://jira.extge.co.uk/browse/INFRA-11107)]