### PR TITLE
INFRA-11107 Added dependencies binutils 2.30 (GCCcore-8.1.0)

### DIFF
--- a/easybuild/easyconfigs/h/help2man/help2man-1.47.6-GCCcore-8.1.0.eb
+++ b/easybuild/easyconfigs/h/help2man/help2man-1.47.6-GCCcore-8.1.0.eb
@@ -1,0 +1,25 @@
+easyblock = 'ConfigureMake'
+
+name = 'help2man'
+version = '1.47.6'
+
+homepage = 'https://www.gnu.org/software/help2man/'
+description = """help2man produces simple manual pages from the '--help' and '--version' output of other commands."""
+
+toolchain = {'name': 'GCCcore', 'version': '8.1.0'}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCE_TAR_XZ]
+checksums = ['d91b0295b72a638e4a564f643e4e6d1928779131f628c00f356c13bf336de46f']
+
+builddependencies = [
+    # use same binutils version that was used when building GCC toolchain
+    ('binutils', '2.30', '', True),
+]
+
+sanity_check_paths = {
+    'files': ['bin/help2man'],
+    'dirs': [],
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/m/M4/M4-1.4.18-GCCcore-8.1.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.18-GCCcore-8.1.0.eb
@@ -1,0 +1,29 @@
+easyblock = 'ConfigureMake'
+
+name = 'M4'
+version = '1.4.18'
+
+homepage = 'http://www.gnu.org/software/m4/m4.html'
+description = """GNU M4 is an implementation of the traditional Unix macro processor. It is mostly SVR4 compatible
+  although it has some extensions (for example, handling more than 9 positional parameters to macros).
+ GNU M4 also has built-in functions for including files, running shell commands, doing arithmetic, etc."""
+
+toolchain = {'name': 'GCCcore', 'version': '8.1.0'}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['ab2633921a5cd38e48797bf5521ad259bdc4b979078034a3b790d7fec5493fab']
+
+# use same binutils version that was used when building GCC toolchain
+builddependencies = [('binutils', '2.30', '', True)]
+
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
+configopts = "--enable-c++ CPPFLAGS=-fgnu89-inline"
+
+sanity_check_paths = {
+    'files': ['bin/m4'],
+    'dirs': [],
+}
+
+moduleclass = 'devel'


### PR DESCRIPTION
This change is necessary because:
 
* binutils v2.30 (GCCcore-8.1.0) have unresolved dependencies
 
The issue is resolved in this commit by:
 
* Added missing dependencies
 
[Jira: [INFRA-11107](https://jira.extge.co.uk/browse/INFRA-11107)]