### PR TITLE
INFRA-11107 Added binutils 2.30 receipe

### DIFF
--- a/easybuild/easyconfigs/b/binutils/binutils-2.30.eb
+++ b/easybuild/easyconfigs/b/binutils/binutils-2.30.eb
@@ -1,0 +1,25 @@
+name = 'binutils'
+version = '2.30'
+
+homepage = 'http://directory.fsf.org/project/binutils/'
+
+description = "binutils: GNU binary utilities"
+
+toolchain = {'name': 'dummy', 'version': ''}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCE_TAR_GZ]
+patches = ['binutils-%(version)s_fix-assertion-fail-elf.patch']
+checksums = [
+    '8c3850195d1c093d290a716e20ebcaa72eda32abf5e3d8611154b39cff79e9ea',  # binutils-2.30.tar.gz
+    '7a661190c973287642296dd9fb30ff45dc26ae2138f7761cd8362f7e412ff5ab',  # binutils-2.30_fix-assertion-fail-elf.patch
+]
+
+builddependencies = [
+    ('flex', '2.6.4'),
+    ('Bison', '3.0.4'),
+    # zlib required, but being linked in statically, so not a runtime dep
+    ('zlib', '1.2.11'),
+]
+
+moduleclass = 'tools'


### PR DESCRIPTION
This change is necessary because:
 
* Missing easybuild recipe
 
The issue is resolved in this commit by:
 
* Added binutils-2.30 recipe from public Easybuild repository
 
[Jira: [INFRA-11107](https://jira.extge.co.uk/browse/INFRA-11107)]