### PR TITLE
INFRA-10417 Added MCR-R2017b and Java dependency

### DIFF
--- a/easybuild/easyconfigs/j/Java/Java-1.8.0_181.eb
+++ b/easybuild/easyconfigs/j/Java/Java-1.8.0_181.eb
@@ -1,0 +1,17 @@
+name = 'Java'
+version = '1.8.0_181'
+
+homepage = 'http://java.com/'
+description = """Java Platform, Standard Edition (Java SE) lets you develop and deploy
+ Java applications on desktops and servers."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+# download the tar.gz directly from
+# http://www.oracle.com/technetwork/java/javase/downloads/index.html
+(vp, vs) = version.split('_')
+altver = '%su%s' % (vp.split('.')[1], vs)
+sources = ['jdk-%s-linux-x64.tar.gz' % altver]
+checksums = ['1845567095bfbfebd42ed0d09397939796d05456290fb20a83c476ba09f991d3']
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/m/MCR/MCR-R2017b.eb
+++ b/easybuild/easyconfigs/m/MCR/MCR-R2017b.eb
@@ -1,0 +1,18 @@
+name = 'MCR'
+version = 'R2017b'
+
+homepage = 'http://www.mathworks.com/products/compiler/mcr/'
+description = """The MATLAB Runtime is a standalone set of shared libraries
+ that enables the execution of compiled MATLAB applications
+ or components on computers that do not have MATLAB installed."""
+
+toolchain = {'name': 'dummy', 'version': ''}
+
+source_urls = [
+    'http://www.mathworks.com/supportfiles/downloads/%(version)s/deployment_files/%(version)s/installers/glnxa64/',
+]
+sources = ['%(name)s_%(version)s_glnxa64_installer.zip']
+
+dependencies = [('Java', '1.8.0_181')]
+
+moduleclass = 'math'


### PR DESCRIPTION
This change is necessary because:
 
*MATLAB Compiler Runtime (MCR) v2017b is requried
 
The issue is resolved in this commit by:
 
* Added Easybuild recipes for installing MCR
 
[Jira: [INFRA-10417](https://jira.extge.co.uk/browse/INFRA-10417)]