### PR TITLE
INFRA-11407 Updated recipe LUMPY-0.2.13-foss-2016b.eb

### DIFF
--- a/easybuild/easyconfigs/l/LUMPY/LUMPY-0.2.13-foss-2016b.eb
+++ b/easybuild/easyconfigs/l/LUMPY/LUMPY-0.2.13-foss-2016b.eb
@@ -24,6 +24,20 @@ toolchainopts = {'usempi': True}
 source_urls = ['https://github.com/arq5x/lumpy-sv/archive/']
 sources = ['%(version)s.tar.gz']
 
+builddependencies = [
+    ('CMake', '3.4.3'),
+    ('Autotools', '20150215', '', True),
+]
+
+dependencies = [
+    ('Python', '2.7.11'),
+    ('zlib', '1.2.8'),
+    ('samblaster', '0.1.24'),
+    ('SAMtools', '1.3.1'),
+    ('Sambamba', '0.6.6', '', True),
+    ('gawk', '4.0.2'),
+]
+
 files_to_copy = [(['bin/*'], 'bin'), 'data', 'LICENSE']
 
 sanity_check_paths = {


### PR DESCRIPTION
This change is necessary because:

* LUMPY-0.2.13-foss-2016b.eb does not have dependencies 

The issue is resolved in this commit by:

* Updated recipe LUMPY-0.2.13-foss-2016b.eb included dependencies 

[Jira: [INFRA-11407](https://jira.extge.co.uk/browse/INFRA-11407]

