### PR TITLE
INFRA-11407 Added dependencies for Lumpy package

### DIFF
--- a/easybuild/easyconfigs/g/gawk/gawk-4.0.2-foss-2016b.eb
+++ b/easybuild/easyconfigs/g/gawk/gawk-4.0.2-foss-2016b.eb
@@ -1,0 +1,31 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
+# Authors::   Fotis Georgatos <fotis@cern.ch>
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/
+##
+
+easyblock = 'ConfigureMake'
+
+name = 'gawk'
+version = '4.0.2'
+
+homepage = 'http://www.gnu.org/software/gawk/gawk.html'
+description = "gawk: GNU awk"
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+toolchain = {'name': 'foss', 'version': '2016b'}
+
+sanity_check_paths = {
+    'files': ['bin/gawk'],
+    'dirs': []
+}
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/l/LUMPY/LUMPY-0.2.13-foss-2016b.eb
+++ b/easybuild/easyconfigs/l/LUMPY/LUMPY-0.2.13-foss-2016b.eb
@@ -31,7 +31,7 @@ builddependencies = [
 
 dependencies = [
     ('Python', '2.7.11'),
-    ('zlib', '1.2.8'),
+    ('zlib', '1.2.8', '', ('GCCcore', '5.4.0')),
     ('samblaster', '0.1.24'),
     ('SAMtools', '1.3.1'),
     ('Sambamba', '0.6.6', '', True),

--- a/easybuild/easyconfigs/p/Python/Python-2.7.11-foss-2016b.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.11-foss-2016b.eb
@@ -1,0 +1,137 @@
+name = 'Python'
+version = '2.7.11'
+
+homepage = 'http://python.org/'
+description = """Python is a programming language that lets you work more quickly and integrate your systems
+ more effectively."""
+
+toolchain = {'name': 'foss', 'version': '2016b'}
+toolchainopts = {'pic': True, 'opt': True, 'optarch': True}
+
+numpyversion = '1.10.1'
+scipyversion = '0.16.1'
+
+source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
+sources = [SOURCE_TGZ]
+
+# python needs bzip2 to build the bz2 package
+dependencies = [
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.8', '', ('GCCcore', '5.4.0')),
+    ('libreadline', '6.3'),
+    ('ncurses', '6.0'),
+    ('SQLite', '3.9.2'),
+    ('Tk', '8.6.5'),
+    ('GMP', '6.1.2'),
+    # OS dependency should be preferred if the os version is more recent then this version,
+    # it's nice to have an up to date openssl for security reasons
+    # ('OpenSSL', '1.0.1q'),
+]
+
+osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
+
+# order is important!
+# package versions updated May 28th 2015
+exts_list = [
+    ('setuptools', '18.7.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],
+    }),
+    ('pip', '7.1.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pip/'],
+    }),
+    ('nose', '1.3.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
+    }),
+    ('numpy', numpyversion, {
+        'source_urls': [('http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download')],
+        'patches': ['numpy-1.8.0-mkl.patch'],
+    }),
+    ('scipy', scipyversion, {
+        'source_urls': [('http://sourceforge.net/projects/scipy/files/scipy/%s' % scipyversion, 'download')],
+    }),
+    ('blist', '1.3.6', {
+        'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],
+    }),
+    ('mpi4py', '1.3.1', {
+        'source_urls': ['http://bitbucket.org/mpi4py/mpi4py/downloads/'],
+    }),
+    ('paycheck', '1.0.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/paycheck/'],
+    }),
+    ('argparse', '1.4.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/a/argparse/'],
+    }),
+    ('pbr', '1.8.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pbr/'],
+    }),
+    ('lockfile', '0.12.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/l/lockfile/'],
+    }),
+    ('Cython', '0.23.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cython/'],
+    }),
+    ('six', '1.10.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/six/'],
+    }),
+    ('dateutil', '2.4.2', {
+        'source_tmpl': 'python-%(name)s-%(version)s.tar.gz',
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
+    }),
+    ('deap', '1.0.2', {
+        'source_tmpl': '%(name)s-%(version)s.post2.tar.gz',
+        'source_urls': ['https://pypi.python.org/packages/source/d/deap/'],
+    }),
+    ('decorator', '4.0.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/d/decorator/'],
+    }),
+    ('arff', '2.1.0', {
+        'source_tmpl': 'liac-%(name)s-%(version)s.zip',
+        'source_urls': ['https://pypi.python.org/packages/source/l/liac-arff/'],
+    }),
+    ('pycrypto', '2.6.1', {
+        'modulename': 'Crypto',
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycrypto/'],
+    }),
+    ('ecdsa', '0.13', {
+        'source_urls': ['https://pypi.python.org/packages/source/e/ecdsa/'],
+    }),
+    ('paramiko', '1.16.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/paramiko/'],
+    }),
+    ('pyparsing', '2.0.6', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pyparsing/'],
+    }),
+    ('netifaces', '0.10.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/netifaces'],
+    }),
+    ('netaddr', '0.7.18', {
+        'source_urls': ['https://pypi.python.org/packages/source/n/netaddr'],
+    }),
+    ('funcsigs', '0.4', {
+        'source_urls': ['https://pypi.python.org/packages/source/f/funcsigs'],
+    }),
+    ('mock', '1.3.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/m/mock'],
+    }),
+    ('pytz', '2015.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pytz'],
+    }),
+    ('pandas', '0.17.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pandas'],
+    }),
+    ('enum34', '1.1.2', {
+        'modulename': 'enum',
+        'source_urls': ['https://pypi.python.org/packages/source/e/enum34'],
+    }),
+    ('bitstring', '3.1.3', {
+        # grab tarball from GitHub rather than PyPi since 3.1.3 release on PyPi disappeared;
+        # cfr. https://github.com/scott-griffiths/bitstring/issues/159
+        'source_tmpl': '%(name)s-%(version)s.tar.gz',
+        'source_urls': ['https://github.com/scott-griffiths/bitstring/archive/'],
+    }),
+    ('virtualenv', '14.0.5', {
+        'source_urls': ['https://pypi.python.org/packages/source/v/virtualenv'],
+    }),
+]
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/s/SAMtools/SAMtools-1.3.1-foss-2016b.eb
+++ b/easybuild/easyconfigs/s/SAMtools/SAMtools-1.3.1-foss-2016b.eb
@@ -31,7 +31,7 @@ checksums = [
 
 dependencies = [
     ('ncurses', '6.0'),
-    ('zlib', '1.2.8'),
+    ('zlib', '1.2.8', '', ('GCCcore', '5.4.0')),
     ('bzip2', '1.0.6'),
     ('XZ', '5.2.2'),
 ]

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.9.2-foss-2016b.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.9.2-foss-2016b.eb
@@ -1,0 +1,41 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
+# Authors::   Fotis Georgatos <fotis@cern.ch>
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/
+##
+
+easyblock = 'ConfigureMake'
+
+name = 'SQLite'
+version = '3.9.2'
+
+homepage = 'http://www.sqlite.org/'
+description = 'SQLite: SQL Database Engine in a C Library'
+
+toolchain = {'name': 'foss', 'version': '2016b'}
+
+# eg. http://www.sqlite.org/2014/sqlite-autoconf-3080600.tar.gz
+source_urls = ['http://www.sqlite.org/2015/']
+version_str = '%%(version_major)s%s00' % ''.join('%02d' % int(x) for x in version.split('.')[1:])
+sources = ['sqlite-autoconf-%s.tar.gz' % version_str]
+
+dependencies = [
+    ('libreadline', '6.3'),
+    ('Tcl', '8.6.5'),
+]
+
+parallel = 1
+
+sanity_check_paths = {
+    'files': ['bin/sqlite3', 'include/sqlite3ext.h', 'include/sqlite3.h', 'lib/libsqlite3.a',
+              'lib/libsqlite3.%s' % SHLIB_EXT],
+    'dirs': ['lib/pkgconfig'],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/s/samblaster/samblaster-0.1.24-foss-2016b.eb
+++ b/easybuild/easyconfigs/s/samblaster/samblaster-0.1.24-foss-2016b.eb
@@ -1,7 +1,7 @@
 # This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 # Author: Pablo Escobar Lopez
 # sciCORE - University of Basel
-# SIB Swiss Institute of Bioinformatics
+# SIB Swiss Institute of Bioinformatics 
 
 easyblock = 'MakeCp'
 
@@ -11,7 +11,7 @@ version = '0.1.24'
 homepage = 'https://github.com/GregoryFaust/samblaster'
 description = """samblaster: a tool to mark duplicates and extract discordant and split reads from sam files"""
 
-toolchain = {'name': 'GCCcore', 'version': '6.4.0'}
+toolchain = {'name': 'foss', 'version': '2016b'}
 
 source_urls = ['https://github.com/GregoryFaust/samblaster/archive/']
 sources = ['v.%(version)s.tar.gz']


### PR DESCRIPTION
This change is necessary because:
 
* Lumpy recipe do not have dependency list
 
The issue is resolved in this commit by:
 
* Added dependency recipes to package
 
[Jira: [INFRA-11407](https://jira.extge.co.uk/browse/INFRA-11407)]