### PR TITLE
INFRA-10417 Added MCR R2017a and R2018a

### DIFF
--- a/easybuild/easyconfigs/m/MCR/MCR-R2017a.eb
+++ b/easybuild/easyconfigs/m/MCR/MCR-R2017a.eb
@@ -1,0 +1,18 @@
+name = 'MCR'
+version = 'R2017a'
+
+homepage = 'http://www.mathworks.com/products/compiler/mcr/'
+description = """The MATLAB Runtime is a standalone set of shared libraries
+ that enables the execution of compiled MATLAB applications
+ or components on computers that do not have MATLAB installed."""
+
+toolchain = {'name': 'dummy', 'version': ''}
+
+source_urls = [
+    'http://www.mathworks.com/supportfiles/downloads/%(version)s/deployment_files/%(version)s/installers/glnxa64/',
+]
+sources = ['%(name)s_%(version)s_glnxa64_installer.zip']
+
+dependencies = [('Java', '1.8.0_181')]
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/m/MCR/MCR-R2018a.eb
+++ b/easybuild/easyconfigs/m/MCR/MCR-R2018a.eb
@@ -1,0 +1,18 @@
+name = 'MCR'
+version = 'R2018a'
+
+homepage = 'http://www.mathworks.com/products/compiler/mcr/'
+description = """The MATLAB Runtime is a standalone set of shared libraries
+ that enables the execution of compiled MATLAB applications
+ or components on computers that do not have MATLAB installed."""
+
+toolchain = {'name': 'dummy', 'version': ''}
+
+source_urls = [
+    'http://www.mathworks.com/supportfiles/downloads/%(version)s/deployment_files/%(version)s/installers/glnxa64/',
+]
+sources = ['%(name)s_%(version)s_glnxa64_installer.zip']
+
+dependencies = [('Java', '1.8.0_181')]
+
+moduleclass = 'math'


### PR DESCRIPTION
This change is necessary because:
 
* Muliple MCR versions required
 
The issue is resolved in this commit by:
 
* Added EB receipes for MCR R2017a and R2018a
 
[Jira: [INFRA-10417](https://jira.extge.co.uk/browse/INFRA-10417)]