### PR TITLE
INFRA-11162 Add Matplotlib module

### DIFF
--- a/easybuild/easyconfigs/f/freetype/freetype-2.7-foss-2017a.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.7-foss-2017a.eb
@@ -1,0 +1,28 @@
+name = 'freetype'
+version = '2.7'
+
+homepage = 'http://freetype.org'
+description = """FreeType 2 is a software font engine that is designed to be small, efficient, highly customizable, and
+ portable while capable of producing high-quality output (glyph images). It can be used in graphics libraries, display
+ servers, font conversion tools, text image generation tools, and many other products as well."""
+
+toolchain = {'name': 'foss', 'version': '2017a'}
+
+source_urls = [GNU_SAVANNAH_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+dependencies = [
+    ('libpng', '1.6.26'),
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.8'),
+]
+
+configopts = '--with-harfbuzz=no'
+
+sanity_check_paths = {
+    'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.%s' % SHLIB_EXT,
+              'lib/pkgconfig/freetype2.pc'],
+    'dirs': ['include/freetype2'],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/l/libpng/libpng-1.6.26-foss-2017a.eb
+++ b/easybuild/easyconfigs/l/libpng/libpng-1.6.26-foss-2017a.eb
@@ -1,0 +1,26 @@
+easyblock = 'ConfigureMake'
+
+name = 'libpng'
+version = '1.6.26'
+
+homepage = 'http://www.libpng.org/pub/png/libpng.html'
+description = "libpng is the official PNG reference library"
+
+toolchain = {'name': 'foss', 'version': '2017a'}
+toolchainopts = {'pic': True}
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [('zlib', '1.2.8')]
+
+configopts = "--with-pic"
+
+majminver = ''.join(version.split('.')[:2])
+sanity_check_paths = {
+    'files': ['include/pngconf.h', 'include/png.h', 'include/pnglibconf.h', 'lib/libpng.a',
+              'lib/libpng.%s' % SHLIB_EXT, 'lib/libpng%s.a' % majminver, 'lib/libpng%s.%s' % (majminver, SHLIB_EXT)],
+    'dirs': ['bin', 'include/libpng%s' % majminver, 'share/man'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.1-foss-2017a-Python-3.6.1.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.1.1-foss-2017a-Python-3.6.1.eb
@@ -1,0 +1,49 @@
+easyblock = 'Bundle'
+
+name = 'matplotlib'
+version = '2.1.1'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://matplotlib.org'
+description = """matplotlib is a python 2D plotting library which produces publication quality figures in a variety of
+ hardcopy formats and interactive environments across platforms. matplotlib can be used in python scripts, the python
+ and ipython shell, web application servers, and six graphical user interface toolkits."""
+
+toolchain = {'name': 'foss', 'version': '2017a'}
+
+# this is a bundle of Python packages
+exts_defaultclass = 'PythonPackage'
+
+dependencies = [
+    ('Python', '3.6.1'),
+    ('Tkinter', '%(pyver)s', versionsuffix),
+#    ('libpng', '1.6.26'),
+#    ('freetype', '2.7'),
+]
+
+exts_list = [
+    ('Cycler', '0.10.0', {
+        'modulename': 'cycler',
+        'source_tmpl': 'cycler-%(version)s.tar.gz',
+        'source_urls': ['https://pypi.python.org/packages/source/C/Cycler'],
+        'checksums': ['cd7b2d1018258d7247a71425e9f26463dfb444d411c39569972f4ce586b0c9d8'],
+    }),
+    (name, version, {
+        'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib'],
+        'checksums': ['659f5e1aa0e0f01488c61eff47560c43b8be511c6a29293d7f3896ae17bd8b23'],
+    }),
+]
+
+# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
+full_sanity_check = True
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_check_commands = ["""python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """]
+
+modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/t/Tk/Tk-8.6.6-foss-2017a.eb
+++ b/easybuild/easyconfigs/t/Tk/Tk-8.6.6-foss-2017a.eb
@@ -1,0 +1,30 @@
+easyblock = 'ConfigureMake'
+
+name = 'Tk'
+version = '8.6.6'
+
+homepage = 'http://www.tcl.tk/'
+description = """Tk is an open source, cross-platform widget toolchain that provides a library of basic elements for
+ building a graphical user interface (GUI) in many different programming languages."""
+
+toolchain = {'name': 'foss', 'version': '2017a'}
+
+source_urls = ["http://prdownloads.sourceforge.net/tcl"]
+sources = ['%(namelower)s%(version)s-src.tar.gz']
+patches = ['Tk-8.6.4_different-prefix-with-tcl.patch']
+checksums = [
+    'd62c371a71b4744ed830e3c21d27968c31dba74dd2c45f36b9b071e6d88eb19d',  # tk8.6.6-src.tar.gz
+    '7a6daa8349393af3d340e774aebf07c7410c51e01bc654ceb3679877063b961d',  # Tk-8.6.4_different-prefix-with-tcl.patch
+]
+
+dependencies = [
+    ('X11', '20170314'),
+    ('Tcl', version),
+    ('zlib', '1.2.11'),
+]
+
+configopts = '--enable-threads --with-tcl=$EBROOTTCL/lib CFLAGS="-I$EBROOTTCL/include"'
+
+start_dir = 'unix'
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/t/Tkinter/Tkinter-3.6.1-foss-2017a-Python-3.6.1.eb
+++ b/easybuild/easyconfigs/t/Tkinter/Tkinter-3.6.1-foss-2017a-Python-3.6.1.eb
@@ -1,0 +1,21 @@
+name = 'Tkinter'
+version = '3.6.1'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'http://python.org/'
+description = """Tkinter module, built with the Python buildsystem"""
+
+toolchain = {'name': 'foss', 'version': '2017a'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://www.python.org/ftp/python/%(version)s/']
+sources = ['Python-%(version)s.tgz']
+checksums = ['aa50b0143df7c89ce91be020fe41382613a817354b33acdc6641b44f8ced3828']
+
+dependencies = [
+    ('Python', '3.6.1'),
+    ('Tk', '8.6.6'),
+    ('zlib', '1.2.11'),
+]
+
+moduleclass = 'lang'


### PR DESCRIPTION
This change is necessary because:

* Matplotlib in python to plot some images fails when run import matplotlib.pyplot as plt 

The issue is resolved in this commit by:

* Add Matplotlib plus dependencies

[Jira: [INFRA-11162](https://jira.extge.co.uk/browse/INFRA-11162)]

